### PR TITLE
Elasticsearch utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Mac .DS_Store files
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for engage_scraper
 
+## v0.0.29
+- Added elasticsearch ETL `elasticsearch/es_utils.py` to load agenda items once they have been scrapped. 
+
 ## v0.0.28
 
 - Add twitter capacity with TwitterUtil class in tweet.py in scraper_utils. Must pass init values from [Twitter Developer Apps](https://developer.twitter.com/en/apps)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for engage_scraper
 
-## v0.0.29
+## v0.0.30
 - Added elasticsearch ETL `elasticsearch/es_utils.py` to load agenda items once they have been scrapped. 
 
 ## v0.0.28

--- a/engage_scraper/elasticsearch/es_utils.py
+++ b/engage_scraper/elasticsearch/es_utils.py
@@ -1,0 +1,56 @@
+import requests
+import os
+import json
+
+ES_INDEX_NAME = os.environ.get('ES_INDEX_NAME', 'agenda_items')
+ES_ENPOINT_NAME = os.environ.get('ES_ENDPOINT_NAME', 'es01')
+
+class ElasticsearchUtility():
+    @staticmethod
+    def loadItems(items=None):
+        """
+        helper function to load scrapped agenda item to elastic search
+
+            Args: 
+                items: dict, key/value pairs representing elasticseaech index fileds. The accepted
+                        keys are:
+                            - date: date, meeting date
+                            - agenda_item_id: int, agenda item id
+                            - agenda_id: int, the id of the specific meeting
+                            - title: str, the title of the agenda
+                            - recommendations: str, the propposed recommendation from the city
+                            - body: str, details about the items
+                            - department: list, all departments concerned with the item
+                            - sponsors: str,
+                            - tags: None
+                            - committee: str, the name of the comittee,
+                            - committee_id: int, the id of the comitte
+            Returns:
+                str, 
+        """
+
+        url = f'http://{ES_ENPOINT_NAME}:9200/{ES_INDEX_NAME}/_doc/'
+
+        payload = {
+            'date': items.get('date'),
+            'agenda_item_id': int(items.get('agenda_item_id')),
+            'agenda_id': items.get('agenda_id'),
+            'title': items.get('title'),
+            'recommendations': items.get('recommendations'),
+            'body': items.get('body'),
+            'department': items.get('department').split(','),
+            'sponsors': items.get('sponsors'),
+            'tags': items.get('tags'),
+            'committee': items.get('committee'),
+            'committee_id': items.get('committee_id'),
+        }
+
+        r = requests.post(url, json=payload)
+        response = json.loads(r.text)
+
+        if not response.get('_shards'):
+            err = response.get("error")
+            return f"Failed to load 1 agenda item.\nerror: {err}"
+        else:
+            index, id = response.get('_index'), response.get('_id')
+            return f"Loaded 1 agenda item in elasticsearch index {index}, with document id {id}"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="engage_scraper",
-    version="0.0.27",
+    version="0.0.30",
     author="Engage",
     author_email="eli.j.selkin@gmail.com",
     description="An agenda scraper framework for municipalities",


### PR DESCRIPTION
Added logic to the load scrapped agenda item to the elasticsearch index. The feature will be disabled by default - lighter dev set up. to enable it you will need to create 1 environment variable `ES_ENABLED=True`.